### PR TITLE
fix: updateWebview now stops when WebView closes

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -108,6 +108,8 @@ function updateMetrics(metrics: Metrics)
 	return metrics;
 }
 
+
+
 // This method is called when your extension is activated
 // Your extension is activated the very first time the command is executed
 export function activate(context: vscode.ExtensionContext) {
@@ -147,6 +149,16 @@ export function activate(context: vscode.ExtensionContext) {
 
 	setInterval(updateTimeTracker, 1000); // update time tracker every second
 
+	const updateMetricsObj = () =>
+	/**
+	 * Arrow function to update metrics object
+	 */
+	{
+		metrics = updateMetrics(metrics);
+	};
+
+	setInterval(updateMetricsObj, 1000) // update metrics every second
+
 	// The command has been defined in the package.json file
 	// Now provide the implementation of the command with registerCommand
 	// The commandId parameter must match the command field in package.json
@@ -168,8 +180,6 @@ export function activate(context: vscode.ExtensionContext) {
 		  panel.webview.html = getWebviewContent(metrics);
 		// update webview every second
 		  const updateWebview = () => {
-			metrics = updateMetrics(metrics);
-			context.globalState.update("metrics", metrics); // write updated metrics to storage
 			panel.webview.html = getWebviewContent(metrics);
 		  };
 	
@@ -177,7 +187,14 @@ export function activate(context: vscode.ExtensionContext) {
 		  updateWebview();
 	
 		  // And schedule updates to the content every second
-		  setInterval(updateWebview, 1000);
+		  const webViewUpdateInterval = setInterval(updateWebview, 1000);
+
+		  panel.onDidDispose(
+			() => {
+			  // When the panel is closed, cancel any future updates to the webview content
+			  clearInterval(webViewUpdateInterval);
+			},
+			null, context.subscriptions);
 	});
 
 	let resetDataCommand = vscode.commands.registerCommand('devmetrics.resetData', () =>


### PR DESCRIPTION
Fixed updateWebView() function behaviour. Now it stops running if WebView was closed.